### PR TITLE
Clap hosting (fake)

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Crate"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,21 +180,10 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
 ]
 
 [[package]]
@@ -234,21 +223,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.3.1",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "async-io"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,7 +247,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -295,14 +269,14 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.3.1",
+ "event-listener",
  "futures-lite",
  "rustix",
  "tracing",
@@ -335,32 +309,6 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -475,7 +423,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -1137,12 +1085,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
@@ -1158,7 +1100,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1401,7 +1343,7 @@ name = "generic-daw"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-std",
+ "async-channel",
  "atomic_enum",
  "clack-extensions",
  "clack-host",
@@ -1478,18 +1420,6 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "glow"
@@ -2154,15 +2084,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,9 +2165,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru"
@@ -4254,12 +4172,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "value-bag"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5117,7 +5029,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener 5.3.1",
+ "event-listener",
  "futures-core",
  "futures-util",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,10 +180,21 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener",
+ "event-listener 5.3.1",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
 ]
 
 [[package]]
@@ -223,6 +234,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "async-io"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,7 +273,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener",
+ "event-listener 5.3.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -269,14 +295,14 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
- "async-channel",
+ "async-channel 2.3.1",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 5.3.1",
  "futures-lite",
  "rustix",
  "tracing",
@@ -309,6 +335,32 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -423,7 +475,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
- "async-channel",
+ "async-channel 2.3.1",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -1085,6 +1137,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
@@ -1100,7 +1158,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
- "event-listener",
+ "event-listener 5.3.1",
  "pin-project-lite",
 ]
 
@@ -1343,7 +1401,7 @@ name = "generic-daw"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-channel",
+ "async-std",
  "atomic_enum",
  "clack-extensions",
  "clack-host",
@@ -1420,6 +1478,18 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "glow"
@@ -2084,6 +2154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,6 +2244,9 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -4172,6 +4254,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "value-bag"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5029,7 +5117,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener",
+ "event-listener 5.3.1",
  "futures-core",
  "futures-util",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4972,9 +4972,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8b391c9a790b496184c29f7f93b9ed5b16abb306c05415b68bcc16e4d06432"
+checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
 
 [[package]]
 name = "xmlwriter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,9 +319,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.84"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2852,9 +2852,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -2862,9 +2862,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand",
@@ -2872,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2885,11 +2885,11 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 0.3.11",
+ "siphasher",
 ]
 
 [[package]]
@@ -3424,12 +3424,6 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
@@ -3616,7 +3610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "794de53cc48eaabeed0ab6a3404a65f40b3e38c067e4435883a65d2aa4ca000e"
 dependencies = [
  "kurbo 0.11.1",
- "siphasher 1.0.1",
+ "siphasher",
 ]
 
 [[package]]
@@ -4163,7 +4157,7 @@ dependencies = [
  "roxmltree",
  "rustybuzz",
  "simplecss",
- "siphasher 1.0.1",
+ "siphasher",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -2134,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3279,14 +3279,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.14",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,26 +1339,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-clap-host"
-version = "0.1.0"
-source = "git+https://github.com/generic-daw/generic-clap-host#26fdd2318fce64a245e0800d7181de64812957b1"
-dependencies = [
- "clack-extensions",
- "clack-host",
- "etcetera",
- "walkdir",
- "winit",
-]
-
-[[package]]
 name = "generic-daw"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-channel",
  "atomic_enum",
+ "clack-extensions",
+ "clack-host",
  "cpal",
- "generic-clap-host",
+ "etcetera",
  "home",
  "hound",
  "iced",
@@ -1373,6 +1363,8 @@ dependencies = [
  "rubato",
  "strum",
  "symphonia",
+ "walkdir",
+ "winit",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-only"
 
 [dependencies]
 anyhow = "1.0.95"
-async-channel = "2.3.1"
+async-std = "1.13.0"
 atomic_enum = { version = "0.3.0", default-features = false }
 clack-extensions = { git = "https://github.com/prokopyl/clack.git", features = [
     "audio-ports",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-only"
 
 [dependencies]
 anyhow = "1.0.95"
-async-std = "1.13.0"
+async-channel = "2.3.1"
 atomic_enum = { version = "0.3.0", default-features = false }
 clack-extensions = { git = "https://github.com/prokopyl/clack.git", features = [
     "audio-ports",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,18 @@ license = "GPL-3.0-only"
 anyhow = "1.0.95"
 async-channel = "2.3.1"
 atomic_enum = { version = "0.3.0", default-features = false }
-cpal = "0.15.3"
-generic-clap-host = { git = "https://github.com/generic-daw/generic-clap-host", features = [
+clack-extensions = { git = "https://github.com/prokopyl/clack.git", features = [
     "audio-ports",
+    "clack-host",
     "gui",
     "note-ports",
     "params",
+    "raw-window-handle_06",
     "state",
     "timer",
 ] }
+clack-host = { git = "https://github.com/prokopyl/clack.git" }
+cpal = "0.15.3"
 home = "0.5.11"
 hound = "3.5.1"
 iced = { version = "0.13.1", default-features = false, features = [
@@ -39,6 +42,11 @@ rfd = "0.15.2"
 rubato = { version = "0.16.1", default-features = false }
 strum = { version = "0.26.3", features = ["derive"] }
 symphonia = { version = "0.5.4", features = ["all", "opt-simd"] }
+walkdir = "2.5.0"
+winit = "0.30.8"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+etcetera = "0.8.0"
 
 [lints.rust]
 let-underscore = "warn"

--- a/src/clap_host/audio_processor.rs
+++ b/src/clap_host/audio_processor.rs
@@ -1,0 +1,67 @@
+use super::Host;
+use clack_host::{prelude::*, process::StartedPluginAudioProcessor};
+use std::sync::atomic::{AtomicU64, Ordering::SeqCst};
+
+pub struct AudioProcessor {
+    started_audio_processor: Option<StartedPluginAudioProcessor<Host>>,
+    steady_time: AtomicU64,
+}
+
+impl AudioProcessor {
+    pub fn new(audio_processor: StartedPluginAudioProcessor<Host>) -> Self {
+        Self {
+            started_audio_processor: Some(audio_processor),
+            steady_time: AtomicU64::new(0),
+        }
+    }
+
+    pub fn steady_time(&self) -> u64 {
+        self.steady_time.load(SeqCst)
+    }
+
+    pub fn process(
+        &mut self,
+        #[expect(clippy::ptr_arg)] input_audio_buffers: &mut Vec<Vec<f32>>,
+        input_events_buffer: &EventBuffer,
+        input_ports: &mut AudioPorts,
+        output_ports: &mut AudioPorts,
+    ) -> (Vec<Vec<f32>>, EventBuffer) {
+        let mut output_audio_buffers = input_audio_buffers.clone();
+
+        let input_audio = input_ports.with_input_buffers([AudioPortBuffer {
+            latency: 0,
+            channels: AudioPortBufferType::f32_input_only(
+                input_audio_buffers.iter_mut().map(InputChannel::constant),
+            ),
+        }]);
+
+        let mut output_audio = output_ports.with_output_buffers([AudioPortBuffer {
+            latency: 0,
+            channels: AudioPortBufferType::f32_output_only(
+                output_audio_buffers.iter_mut().map(Vec::as_mut_slice),
+            ),
+        }]);
+
+        let input_events = InputEvents::from_buffer(input_events_buffer);
+        let mut output_events_buffer = EventBuffer::new();
+        let mut output_events = OutputEvents::from_buffer(&mut output_events_buffer);
+
+        self.started_audio_processor
+            .as_mut()
+            .unwrap()
+            .process(
+                &input_audio,
+                &mut output_audio,
+                &input_events,
+                &mut output_events,
+                Some(self.steady_time.load(SeqCst)),
+                None,
+            )
+            .unwrap();
+
+        self.steady_time
+            .fetch_add(u64::from(output_audio.frames_count().unwrap()), SeqCst);
+
+        (output_audio_buffers, output_events_buffer)
+    }
+}

--- a/src/clap_host/audio_processor.rs
+++ b/src/clap_host/audio_processor.rs
@@ -21,12 +21,12 @@ impl AudioProcessor {
 
     pub fn process(
         &mut self,
-        #[expect(clippy::ptr_arg)] input_audio_buffers: &mut Vec<Vec<f32>>,
+        input_audio_buffers: &mut [Vec<f32>],
         input_events_buffer: &EventBuffer,
         input_ports: &mut AudioPorts,
         output_ports: &mut AudioPorts,
     ) -> (Vec<Vec<f32>>, EventBuffer) {
-        let mut output_audio_buffers = input_audio_buffers.clone();
+        let mut output_audio_buffers = input_audio_buffers.to_owned();
 
         let input_audio = input_ports.with_input_buffers([AudioPortBuffer {
             latency: 0,

--- a/src/clap_host/clap_plugin.rs
+++ b/src/clap_host/clap_plugin.rs
@@ -1,0 +1,105 @@
+use super::{
+    gui::GuiExt,
+    host::{Host, HostThreadMessage},
+    main_thread::MainThreadMessage,
+};
+use clack_host::{
+    plugin::PluginInstance,
+    prelude::{AudioPorts, EventBuffer},
+};
+use std::{
+    fmt::Debug,
+    sync::mpsc::{Receiver, Sender},
+};
+use winit::dpi::Size;
+
+pub struct ClapPlugin {
+    instance: PluginInstance<Host>,
+    gui: GuiExt,
+    sender: Sender<MainThreadMessage>,
+    receiver: Receiver<HostThreadMessage>,
+}
+
+impl Debug for ClapPlugin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClapPlugin").finish_non_exhaustive()
+    }
+}
+
+impl ClapPlugin {
+    pub fn new(
+        instance: PluginInstance<Host>,
+        gui: GuiExt,
+        sender: Sender<MainThreadMessage>,
+        receiver: Receiver<HostThreadMessage>,
+    ) -> Self {
+        Self {
+            instance,
+            gui,
+            sender,
+            receiver,
+        }
+    }
+
+    pub fn process_audio(
+        &self,
+        input_audio: Vec<Vec<f32>>,
+        input_audio_ports: AudioPorts,
+        output_audio_ports: AudioPorts,
+        input_events: EventBuffer,
+    ) -> (Vec<Vec<f32>>, EventBuffer) {
+        self.sender
+            .send(MainThreadMessage::ProcessAudio(
+                input_audio,
+                input_audio_ports,
+                output_audio_ports,
+                input_events,
+            ))
+            .unwrap();
+
+        match self.receiver.recv() {
+            Ok(HostThreadMessage::AudioProcessed(output_audio, output_events)) => {
+                (output_audio, output_events)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn get_counter(&self) -> u64 {
+        self.sender.send(MainThreadMessage::GetCounter).unwrap();
+
+        match self.receiver.recv() {
+            Ok(HostThreadMessage::Counter(counter)) => counter,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn get_state(&self) -> Vec<u8> {
+        self.sender.send(MainThreadMessage::GetState).unwrap();
+
+        match self.receiver.recv() {
+            Ok(HostThreadMessage::State(state)) => state,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn set_state(&self, state: Vec<u8>) {
+        self.sender
+            .send(MainThreadMessage::SetState(state))
+            .unwrap();
+    }
+
+    pub fn resize(&mut self, size: iced::Size) {
+        self.gui.resize(
+            &mut self.instance.plugin_handle(),
+            Size::Physical(winit::dpi::PhysicalSize::new(
+                size.width as u32,
+                size.height as u32,
+            )),
+        );
+    }
+
+    pub fn destroy(mut self) {
+        self.gui.destroy(&mut self.instance.plugin_handle());
+    }
+}

--- a/src/clap_host/clap_plugin_wrapper.rs
+++ b/src/clap_host/clap_plugin_wrapper.rs
@@ -1,0 +1,26 @@
+use crate::clap_host::ClapPlugin;
+use std::rc::Rc;
+
+/// SAFETY: ONLY USE THIS TO GET THE PLUGIN
+/// FROM `iced::window::run_with_handle` TO
+/// THE `clap_host` VIEW
+#[derive(Clone, Debug)]
+pub struct ClapPluginWrapper {
+    pub inner: Rc<ClapPlugin>,
+}
+
+#[expect(clippy::non_send_fields_in_send_ty)]
+unsafe impl Send for ClapPluginWrapper {}
+unsafe impl Sync for ClapPluginWrapper {}
+
+impl ClapPluginWrapper {
+    pub fn new(inner: ClapPlugin) -> Self {
+        Self {
+            inner: Rc::new(inner),
+        }
+    }
+
+    pub fn into_inner(self) -> ClapPlugin {
+        Rc::into_inner(self.inner).unwrap()
+    }
+}

--- a/src/clap_host/gui.rs
+++ b/src/clap_host/gui.rs
@@ -1,0 +1,382 @@
+use super::{timer::Timers, AudioProcessor, Host, HostThreadMessage, MainThreadMessage};
+use clack_extensions::{
+    gui::{GuiApiType, GuiConfiguration, GuiSize, PluginGui, Window as ClapWindow},
+    state::PluginState,
+    timer::PluginTimer,
+};
+use clack_host::prelude::*;
+use std::{
+    io::Cursor,
+    rc::Rc,
+    sync::mpsc::{Receiver, Sender},
+    time::{Duration, Instant},
+};
+use winit::{
+    dpi::{LogicalSize, PhysicalSize, Size},
+    event::{Event, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::Window,
+};
+
+pub struct GuiExt {
+    plugin_gui: PluginGui,
+    pub configuration: Option<GuiConfiguration<'static>>,
+    is_open: bool,
+    is_resizeable: bool,
+}
+
+impl GuiExt {
+    pub fn new(plugin_gui: PluginGui, instance: &mut PluginMainThreadHandle<'_>) -> Self {
+        Self {
+            plugin_gui,
+            configuration: Self::negotiate_configuration(&plugin_gui, instance),
+            is_open: false,
+            is_resizeable: false,
+        }
+    }
+
+    fn negotiate_configuration(
+        gui: &PluginGui,
+        plugin: &mut PluginMainThreadHandle<'_>,
+    ) -> Option<GuiConfiguration<'static>> {
+        let api_type = GuiApiType::default_for_current_platform()?;
+        let mut config = GuiConfiguration {
+            api_type,
+            is_floating: false,
+        };
+
+        if gui.is_api_supported(plugin, config) {
+            Some(config)
+        } else {
+            config.is_floating = true;
+            if gui.is_api_supported(plugin, config) {
+                Some(config)
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn gui_size_to_winit_size(&self, size: GuiSize) -> Size {
+        let Some(GuiConfiguration { api_type, .. }) = self.configuration else {
+            panic!("Called gui_size_to_winit_size on incompatible plugin")
+        };
+
+        if api_type.uses_logical_size() {
+            LogicalSize {
+                width: size.width,
+                height: size.height,
+            }
+            .into()
+        } else {
+            PhysicalSize {
+                width: size.width,
+                height: size.height,
+            }
+            .into()
+        }
+    }
+
+    pub fn needs_floating(&self) -> Option<bool> {
+        self.configuration
+            .map(|GuiConfiguration { is_floating, .. }| is_floating)
+    }
+
+    pub fn open_floating(&self, plugin: &mut PluginMainThreadHandle<'_>) {
+        let Some(configuration) = self.configuration else {
+            panic!("Called open_floating on incompatible plugin")
+        };
+        assert!(
+            configuration.is_floating,
+            "Called open_floating on incompatible plugin"
+        );
+
+        self.plugin_gui.create(plugin, configuration).unwrap();
+        self.plugin_gui.suggest_title(plugin, c"");
+        self.plugin_gui.show(plugin).unwrap();
+    }
+
+    pub fn open_embedded(
+        &mut self,
+        plugin: &mut PluginMainThreadHandle<'_>,
+        event_loop: &EventLoop<()>,
+    ) -> Window {
+        let Some(configuration) = self.configuration else {
+            panic!("Called open_embedded on incompatible plugin")
+        };
+        assert!(
+            !configuration.is_floating,
+            "Called open_embedded on incompatible plugin"
+        );
+
+        self.plugin_gui.create(plugin, configuration).unwrap();
+
+        let initial_size = self.plugin_gui.get_size(plugin).unwrap_or(GuiSize {
+            width: 640,
+            height: 480,
+        });
+
+        self.is_resizeable = self.plugin_gui.can_resize(plugin);
+
+        #[expect(deprecated)] // TODO: remove this
+        let window = event_loop
+            .create_window(
+                Window::default_attributes()
+                    .with_title("Clack CPAL plugin!")
+                    .with_inner_size(PhysicalSize {
+                        height: initial_size.height,
+                        width: initial_size.width,
+                    })
+                    .with_resizable(self.is_resizeable),
+            )
+            .unwrap();
+
+        unsafe {
+            self.plugin_gui
+                .set_parent(plugin, ClapWindow::from_window(&window).unwrap())
+                .unwrap();
+        }
+
+        let _ = self.plugin_gui.show(plugin);
+        self.is_open = true;
+
+        window
+    }
+
+    pub fn resize(
+        &self,
+        plugin: &mut PluginMainThreadHandle<'_>,
+        size: Size,
+        scale_factor: f64,
+    ) -> Size {
+        let uses_logical_pixels = self.configuration.unwrap().api_type.uses_logical_size();
+
+        let size = if uses_logical_pixels {
+            let size = size.to_logical(scale_factor);
+            GuiSize {
+                width: size.width,
+                height: size.height,
+            }
+        } else {
+            let size = size.to_physical(scale_factor);
+            GuiSize {
+                width: size.width,
+                height: size.height,
+            }
+        };
+
+        if !self.is_resizeable {
+            let forced_size = self.plugin_gui.get_size(plugin).unwrap_or(size);
+
+            return self.gui_size_to_winit_size(forced_size);
+        }
+
+        let working_size = self.plugin_gui.adjust_size(plugin, size).unwrap_or(size);
+        self.plugin_gui.set_size(plugin, working_size).unwrap();
+
+        self.gui_size_to_winit_size(working_size)
+    }
+
+    pub fn destroy(&mut self, plugin: &mut PluginMainThreadHandle<'_>) {
+        if self.is_open {
+            self.plugin_gui.destroy(plugin);
+            self.is_open = false;
+        }
+    }
+
+    pub fn run_gui_embedded(
+        &mut self,
+        mut instance: PluginInstance<Host>,
+        sender: &Sender<HostThreadMessage>,
+        receiver: &Receiver<MainThreadMessage>,
+        audio_processor: &mut AudioProcessor,
+    ) {
+        let event_loop = EventLoop::new().unwrap();
+
+        let mut window = Some(self.open_embedded(&mut instance.plugin_handle(), &event_loop));
+
+        let uses_logical_pixels = self.configuration.unwrap().api_type.uses_logical_size();
+
+        let timers =
+            instance.access_handler(|h| h.timer_support.map(|ext| (h.timers.clone(), ext)));
+
+        #[expect(deprecated)]
+        event_loop
+            .run(move |event, target| {
+                if let Some((timers, timer_ext)) = &timers {
+                    timers.tick_timers(timer_ext, &mut instance.plugin_handle());
+                }
+
+                while let Ok(message) = receiver.try_recv() {
+                    match message {
+                        MainThreadMessage::GuiRequestResized(new_size) => {
+                            let new_size: Size = if uses_logical_pixels {
+                                LogicalSize {
+                                    width: new_size.width,
+                                    height: new_size.height,
+                                }
+                                .into()
+                            } else {
+                                PhysicalSize {
+                                    width: new_size.width,
+                                    height: new_size.height,
+                                }
+                                .into()
+                            };
+
+                            let _ = window.as_mut().unwrap().request_inner_size(new_size);
+                        }
+                        _ => Self::do_event(&mut instance, sender, message, audio_processor),
+                    }
+                }
+
+                match event {
+                    Event::WindowEvent { event, .. } => match event {
+                        WindowEvent::CloseRequested => {
+                            self.plugin_gui.destroy(&mut instance.plugin_handle());
+                            window.take();
+                            return;
+                        }
+                        WindowEvent::Destroyed => {
+                            target.exit();
+                            return;
+                        }
+                        WindowEvent::Resized(size) => {
+                            let window = window.as_ref().unwrap();
+                            let scale_factor = window.scale_factor();
+
+                            let actual_size = self.resize(
+                                &mut instance.plugin_handle(),
+                                Size::Physical(size),
+                                scale_factor,
+                            );
+
+                            if actual_size != size.into() {
+                                let _ = window.request_inner_size(actual_size);
+                            }
+                        }
+                        _ => {}
+                    },
+                    Event::LoopExiting => {
+                        self.plugin_gui.destroy(&mut instance.plugin_handle());
+                    }
+                    _ => {}
+                }
+
+                let sleep_duration = Self::get_sleep_duration(timers.as_ref());
+
+                target.set_control_flow(ControlFlow::WaitUntil(Instant::now() + sleep_duration));
+            })
+            .unwrap();
+
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    pub fn run_gui_floating(
+        &mut self,
+        mut instance: PluginInstance<Host>,
+        sender: &Sender<HostThreadMessage>,
+        receiver: &Receiver<MainThreadMessage>,
+        audio_processor: &mut AudioProcessor,
+    ) {
+        self.open_floating(&mut instance.plugin_handle());
+        let timers =
+            instance.access_handler(|h| h.timer_support.map(|ext| (h.timers.clone(), ext)));
+
+        loop {
+            if let Some((timers, timer_ext)) = &timers {
+                timers.tick_timers(timer_ext, &mut instance.plugin_handle());
+            }
+            while let Ok(message) = receiver.try_recv() {
+                match message {
+                    MainThreadMessage::GuiClosed { .. } => {
+                        self.destroy(&mut instance.plugin_handle());
+                        return;
+                    }
+                    MainThreadMessage::GuiRequestResized(new_size) => {
+                        self.resize(
+                            &mut instance.plugin_handle(),
+                            self.gui_size_to_winit_size(new_size),
+                            1.0f64,
+                        );
+                    }
+                    _ => Self::do_event(&mut instance, sender, message, audio_processor),
+                }
+            }
+
+            let sleep_duration = Self::get_sleep_duration(timers.as_ref());
+
+            std::thread::sleep(sleep_duration);
+        }
+    }
+
+    fn do_event(
+        instance: &mut PluginInstance<Host>,
+        sender: &Sender<HostThreadMessage>,
+        message: MainThreadMessage,
+        audio_processor: &mut AudioProcessor,
+    ) {
+        match message {
+            MainThreadMessage::RunOnMainThread => instance.call_on_main_thread_callback(),
+            MainThreadMessage::ProcessAudio(
+                mut input_buffers,
+                mut input_audio_ports,
+                mut output_audio_ports,
+                input_events,
+            ) => {
+                let (output_buffers, output_events) = audio_processor.process(
+                    &mut input_buffers,
+                    &input_events,
+                    &mut input_audio_ports,
+                    &mut output_audio_ports,
+                );
+
+                sender
+                    .send(HostThreadMessage::AudioProcessed(
+                        output_buffers,
+                        output_events,
+                    ))
+                    .unwrap();
+            }
+            MainThreadMessage::GetCounter => {
+                sender
+                    .send(HostThreadMessage::Counter(audio_processor.steady_time()))
+                    .unwrap();
+            }
+            MainThreadMessage::GetState => {
+                let state_ext: PluginState = instance
+                    .access_handler_mut(|h| h.shared.state.get())
+                    .unwrap()
+                    .unwrap();
+
+                let mut state = Vec::new();
+                state_ext
+                    .save(&mut instance.plugin_handle(), &mut state)
+                    .unwrap();
+
+                sender.send(HostThreadMessage::State(state)).unwrap();
+            }
+            MainThreadMessage::SetState(state) => {
+                let state_ext: PluginState = instance
+                    .access_handler_mut(|h| h.shared.state.get())
+                    .unwrap()
+                    .unwrap();
+
+                let mut state = Cursor::new(state);
+
+                state_ext
+                    .load(&mut instance.plugin_handle(), &mut state)
+                    .unwrap();
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn get_sleep_duration(timers: Option<&(Rc<Timers>, PluginTimer)>) -> Duration {
+        timers
+            .as_ref()
+            .and_then(|(timers, _)| Some(timers.next_tick()? - Instant::now()))
+            .unwrap_or(Duration::from_millis(30))
+            .min(Duration::from_millis(30))
+    }
+}

--- a/src/clap_host/host.rs
+++ b/src/clap_host/host.rs
@@ -5,6 +5,7 @@ use clack_extensions::{
 };
 use clack_host::prelude::*;
 
+#[derive(Clone, Copy)]
 pub struct Host;
 
 #[derive(Debug)]

--- a/src/clap_host/host.rs
+++ b/src/clap_host/host.rs
@@ -1,0 +1,30 @@
+use super::{MainThread, Shared};
+use clack_extensions::{
+    audio_ports::HostAudioPorts, gui::HostGui, note_ports::HostNotePorts, params::HostParams,
+    state::HostState, timer::HostTimer,
+};
+use clack_host::prelude::*;
+
+pub struct Host;
+
+#[derive(Debug)]
+pub enum HostThreadMessage {
+    AudioProcessed(Vec<Vec<f32>>, EventBuffer),
+    Counter(u64),
+    State(Vec<u8>),
+}
+
+impl HostHandlers for Host {
+    type Shared<'a> = Shared;
+    type MainThread<'a> = MainThread<'a>;
+    type AudioProcessor<'a> = ();
+
+    fn declare_extensions(builder: &mut HostExtensions<'_, Self>, _shared: &Self::Shared<'_>) {
+        builder.register::<HostAudioPorts>();
+        builder.register::<HostGui>();
+        builder.register::<HostNotePorts>();
+        builder.register::<HostParams>();
+        builder.register::<HostState>();
+        builder.register::<HostTimer>();
+    }
+}

--- a/src/clap_host/main_thread.rs
+++ b/src/clap_host/main_thread.rs
@@ -1,0 +1,102 @@
+use super::{shared::Shared, timer::Timers};
+use clack_extensions::{
+    audio_ports::{HostAudioPortsImpl, RescanType},
+    gui::{GuiSize, PluginGui},
+    note_ports::{HostNotePortsImpl, NoteDialects, NotePortRescanFlags},
+    params::{HostParamsImplMainThread, ParamClearFlags, ParamRescanFlags},
+    state::HostStateImpl,
+    timer::{HostTimerImpl, PluginTimer, TimerId},
+};
+use clack_host::prelude::*;
+use std::{rc::Rc, time::Duration};
+
+pub enum MainThreadMessage {
+    RunOnMainThread,
+    GuiClosed,
+    GuiRequestResized(GuiSize),
+    ProcessAudio(Vec<Vec<f32>>, AudioPorts, AudioPorts, EventBuffer),
+    GetCounter,
+    GetState,
+    SetState(Vec<u8>),
+}
+
+pub struct MainThread<'a> {
+    pub shared: &'a Shared,
+    plugin: Option<InitializedPluginHandle<'a>>,
+    pub gui: Option<PluginGui>,
+    pub timer_support: Option<PluginTimer>,
+    pub timers: Rc<Timers>,
+    pub dirty: bool,
+}
+
+impl<'a> MainThread<'a> {
+    pub fn new(shared: &'a Shared) -> Self {
+        Self {
+            shared,
+            plugin: None,
+            gui: None,
+            timer_support: None,
+            timers: Rc::default(),
+            dirty: false,
+        }
+    }
+}
+
+impl<'a> MainThreadHandler<'a> for MainThread<'a> {
+    fn initialized(&mut self, instance: InitializedPluginHandle<'a>) {
+        self.gui = instance.get_extension();
+        self.timer_support = instance.get_extension();
+        self.timers = Rc::new(Timers::default());
+        self.plugin = Some(instance);
+    }
+}
+
+impl HostAudioPortsImpl for MainThread<'_> {
+    fn is_rescan_flag_supported(&self, _flag: RescanType) -> bool {
+        false
+    }
+
+    fn rescan(&mut self, _flag: RescanType) {
+        // we don't support audio ports changing on the fly (yet)
+    }
+}
+
+impl HostNotePortsImpl for MainThread<'_> {
+    fn supported_dialects(&self) -> NoteDialects {
+        NoteDialects::CLAP
+    }
+
+    fn rescan(&mut self, _flags: NotePortRescanFlags) {
+        // We don't support note ports changing on the fly (yet)
+    }
+}
+
+impl HostParamsImplMainThread for MainThread<'_> {
+    fn clear(&mut self, _id: ClapId, _flags: ParamClearFlags) {}
+
+    fn rescan(&mut self, _flags: ParamRescanFlags) {
+        // We don't track param values (yet)
+    }
+}
+
+impl HostStateImpl for MainThread<'_> {
+    fn mark_dirty(&mut self) {
+        self.dirty = true;
+    }
+}
+
+impl HostTimerImpl for MainThread<'_> {
+    fn register_timer(&mut self, period_ms: u32) -> Result<TimerId, HostError> {
+        Ok(self
+            .timers
+            .register_new(Duration::from_millis(u64::from(period_ms))))
+    }
+
+    fn unregister_timer(&mut self, timer_id: TimerId) -> Result<(), HostError> {
+        if self.timers.unregister(timer_id) {
+            Ok(())
+        } else {
+            Err(HostError::Message("Unknown timer ID"))
+        }
+    }
+}

--- a/src/clap_host/mod.rs
+++ b/src/clap_host/mod.rs
@@ -1,0 +1,201 @@
+use audio_processor::AudioProcessor;
+use clack_host::prelude::*;
+use gui::GuiExt;
+use home::home_dir;
+use host::{Host, HostThreadMessage};
+use main_thread::{MainThread, MainThreadMessage};
+use shared::Shared;
+use std::{
+    cell::UnsafeCell,
+    marker::PhantomData,
+    path::PathBuf,
+    result::Result,
+    sync::mpsc::{Receiver, Sender},
+};
+use walkdir::WalkDir;
+
+mod audio_processor;
+mod gui;
+mod host;
+mod main_thread;
+mod shared;
+mod timer;
+
+#[derive(Debug)]
+pub struct ClapPlugin {
+    sender: Sender<MainThreadMessage>,
+    receiver: Receiver<HostThreadMessage>,
+    _no_sync: PhantomData<UnsafeCell<()>>,
+}
+
+impl ClapPlugin {
+    fn new(sender: Sender<MainThreadMessage>, receiver: Receiver<HostThreadMessage>) -> Self {
+        Self {
+            sender,
+            receiver,
+            _no_sync: PhantomData,
+        }
+    }
+
+    pub fn process_audio(
+        &self,
+        input_audio: Vec<Vec<f32>>,
+        input_audio_ports: AudioPorts,
+        output_audio_ports: AudioPorts,
+        input_events: EventBuffer,
+    ) -> (Vec<Vec<f32>>, EventBuffer) {
+        self.sender
+            .send(MainThreadMessage::ProcessAudio(
+                input_audio,
+                input_audio_ports,
+                output_audio_ports,
+                input_events,
+            ))
+            .unwrap();
+
+        match self.receiver.recv() {
+            Ok(HostThreadMessage::AudioProcessed(output_audio, output_events)) => {
+                (output_audio, output_events)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn get_counter(&self) -> u64 {
+        self.sender.send(MainThreadMessage::GetCounter).unwrap();
+
+        match self.receiver.recv() {
+            Ok(HostThreadMessage::Counter(counter)) => counter,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn get_state(&self) -> Vec<u8> {
+        self.sender.send(MainThreadMessage::GetState).unwrap();
+
+        match self.receiver.recv() {
+            Ok(HostThreadMessage::State(state)) => state,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn set_state(&self, state: Vec<u8>) {
+        self.sender
+            .send(MainThreadMessage::SetState(state))
+            .unwrap();
+    }
+}
+
+#[expect(dead_code)]
+pub fn get_installed_plugins() -> Vec<PluginBundle> {
+    standard_clap_paths()
+        .iter()
+        .flat_map(|path| {
+            WalkDir::new(path)
+                .follow_links(true)
+                .into_iter()
+                .filter_map(Result::ok)
+                .filter(|dir_entry| dir_entry.file_type().is_file())
+                .filter(|dir_entry| {
+                    dir_entry
+                        .path()
+                        .extension()
+                        .is_some_and(|ext| ext == "clap")
+                })
+        })
+        .filter_map(|path| unsafe { PluginBundle::load(path.path()) }.ok())
+        .filter(|bundle| {
+            bundle
+                .get_plugin_factory()
+                .is_some_and(|factory| factory.plugin_descriptors().next().is_some())
+        })
+        .collect()
+}
+
+fn standard_clap_paths() -> Vec<PathBuf> {
+    let mut paths = vec![];
+
+    paths.push(home_dir().unwrap().join(".clap"));
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(val) = std::env::var_os("CommonProgramFiles") {
+            paths.push(PathBuf::from(val).join("CLAP"));
+        }
+
+        use etcetera::BaseStrategy as _;
+
+        paths.push(
+            etcetera::choose_base_strategy()
+                .unwrap()
+                .config_dir()
+                .join("Programs\\Common\\CLAP"),
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        paths.push(home_dir().unwrap().join("Library/Audio/Plug-Ins/CLAP"));
+
+        paths.push(PathBuf::from("/Library/Audio/Plug-Ins/CLAP"));
+    }
+
+    #[cfg(target_os = "linux")]
+    paths.push("/usr/lib/clap".into());
+
+    if let Some(env_var) = std::env::var_os("CLAP_PATH") {
+        paths.extend(std::env::split_paths(&env_var));
+    }
+
+    paths
+}
+
+#[expect(dead_code)]
+pub fn run(bundle: PluginBundle, config: PluginAudioConfiguration) -> ClapPlugin {
+    let (sender_plugin, receiver_plugin) = std::sync::mpsc::channel();
+    let (sender_host, receiver_host) = std::sync::mpsc::channel();
+
+    let sender_plugin_clone = sender_plugin.clone();
+
+    std::thread::spawn(move || {
+        let factory = bundle.get_plugin_factory().unwrap();
+        let plugin_descriptor = factory.plugin_descriptors().next().unwrap();
+        let mut instance = PluginInstance::<Host>::new(
+            |()| Shared::new(sender_plugin_clone),
+            |shared| MainThread::new(shared),
+            &bundle,
+            plugin_descriptor.id().unwrap(),
+            &HostInfo::new("", "", "", "").unwrap(),
+        )
+        .unwrap();
+
+        let audio_processor = instance
+            .activate(|_, _| {}, config)
+            .unwrap()
+            .start_processing()
+            .unwrap();
+
+        let mut gui = instance
+            .access_handler(|h| h.gui)
+            .map(|gui| GuiExt::new(gui, &mut instance.plugin_handle()))
+            .unwrap();
+
+        if gui.needs_floating().unwrap() {
+            gui.run_gui_floating(
+                instance,
+                &sender_host,
+                &receiver_plugin,
+                &mut AudioProcessor::new(audio_processor),
+            );
+        } else {
+            gui.run_gui_embedded(
+                instance,
+                &sender_host,
+                &receiver_plugin,
+                &mut AudioProcessor::new(audio_processor),
+            );
+        }
+    });
+
+    ClapPlugin::new(sender_plugin, receiver_host)
+}

--- a/src/clap_host/shared.rs
+++ b/src/clap_host/shared.rs
@@ -1,0 +1,74 @@
+use super::MainThreadMessage;
+use clack_extensions::{
+    gui::{GuiSize, HostGuiImpl},
+    params::HostParamsImplShared,
+    state::PluginState,
+};
+use clack_host::prelude::*;
+use std::sync::{mpsc::Sender, OnceLock};
+
+pub struct Shared {
+    sender: Sender<MainThreadMessage>,
+    pub state: OnceLock<Option<PluginState>>,
+}
+
+impl SharedHandler<'_> for Shared {
+    fn request_process(&self) {
+        // we never pause
+    }
+
+    fn request_callback(&self) {
+        self.sender
+            .send(MainThreadMessage::RunOnMainThread)
+            .unwrap();
+    }
+
+    fn request_restart(&self) {
+        // we don't support restarting plugins (yet)
+    }
+
+    fn initializing(&self, instance: InitializingPluginHandle<'_>) {
+        self.state.set(instance.get_extension()).ok().unwrap();
+    }
+}
+
+impl HostGuiImpl for Shared {
+    fn resize_hints_changed(&self) {
+        // we don't support resize hints (yet)
+    }
+
+    fn request_resize(&self, new_size: GuiSize) -> Result<(), HostError> {
+        Ok(self
+            .sender
+            .send(MainThreadMessage::GuiRequestResized(new_size))?)
+    }
+
+    fn request_show(&self) -> Result<(), HostError> {
+        // we never hide the window, so showing it does nothing
+        Ok(())
+    }
+
+    fn request_hide(&self) -> Result<(), HostError> {
+        // we never hide the window
+        Ok(())
+    }
+
+    fn closed(&self, _was_destroyed: bool) {
+        self.sender.send(MainThreadMessage::GuiClosed).unwrap();
+    }
+}
+
+impl HostParamsImplShared for Shared {
+    fn request_flush(&self) {
+        // Can never flush events when not processing: we're never not processing
+    }
+}
+
+impl Shared {
+    pub fn new(sender: Sender<MainThreadMessage>) -> Self {
+        Self {
+            sender,
+            state: OnceLock::new(),
+        }
+    }
+}

--- a/src/clap_host/timer.rs
+++ b/src/clap_host/timer.rs
@@ -1,0 +1,123 @@
+use clack_extensions::timer::{PluginTimer, TimerId};
+use clack_host::prelude::*;
+use std::{
+    cell::{Cell, RefCell},
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+pub struct Timers {
+    #[expect(clippy::struct_field_names)]
+    timers: RefCell<HashMap<TimerId, Timer>>,
+    latest_id: Cell<u32>,
+    next_tick: Cell<Option<Instant>>,
+}
+
+impl Default for Timers {
+    fn default() -> Self {
+        Self {
+            timers: RefCell::new(HashMap::new()),
+            latest_id: Cell::new(0),
+            next_tick: Cell::new(None),
+        }
+    }
+}
+
+impl Timers {
+    fn tick_all(&self) -> Vec<TimerId> {
+        let timers = self
+            .timers
+            .borrow_mut()
+            .values_mut()
+            .filter_map(move |t| t.tick().then_some(t.id))
+            .collect();
+
+        self.next_tick
+            .set(self.timers.borrow().values().map(Timer::next_tick).min());
+
+        timers
+    }
+
+    pub fn tick_timers(&self, timer_ext: &PluginTimer, plugin: &mut PluginMainThreadHandle<'_>) {
+        for triggered in self.tick_all() {
+            timer_ext.on_timer(plugin, triggered);
+        }
+    }
+
+    pub fn register_new(&self, interval: Duration) -> TimerId {
+        let latest_id = self.latest_id.get() + 1;
+        self.latest_id.set(latest_id);
+        let id = TimerId(latest_id);
+
+        self.timers
+            .borrow_mut()
+            .insert(id, Timer::new(id, interval));
+
+        let next_tick = Instant::now() + interval;
+        match self.next_tick.get() {
+            None => self.next_tick.set(Some(next_tick)),
+            Some(smallest) if smallest > next_tick => self.next_tick.set(Some(next_tick)),
+            _ => {}
+        }
+
+        id
+    }
+
+    pub fn unregister(&self, id: TimerId) -> bool {
+        let mut timers = self.timers.borrow_mut();
+        if timers.remove(&id).is_some() {
+            self.next_tick.set(
+                timers
+                    .values()
+                    .map(|t| t.last_triggered_at.unwrap_or_else(Instant::now) + t.interval)
+                    .min(),
+            );
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn next_tick(&self) -> Option<Instant> {
+        self.next_tick.get()
+    }
+}
+
+struct Timer {
+    id: TimerId,
+    interval: Duration,
+    last_triggered_at: Option<Instant>,
+}
+
+impl Timer {
+    fn new(id: TimerId, interval: Duration) -> Self {
+        Self {
+            id,
+            interval,
+            last_triggered_at: None,
+        }
+    }
+
+    fn tick(&mut self) -> bool {
+        let now = Instant::now();
+        let triggered = if let Some(last_updated_at) = self.last_triggered_at {
+            if let Some(since) = now.checked_duration_since(last_updated_at) {
+                since >= self.interval
+            } else {
+                false
+            }
+        } else {
+            true
+        };
+
+        if triggered {
+            self.last_triggered_at = Some(now);
+        }
+
+        triggered
+    }
+
+    fn next_tick(&self) -> Instant {
+        self.last_triggered_at.unwrap_or_else(Instant::now) + self.interval
+    }
+}

--- a/src/generic_back/mod.rs
+++ b/src/generic_back/mod.rs
@@ -6,22 +6,19 @@ use std::{
     f32::consts::PI,
     sync::{atomic::Ordering::SeqCst, Arc},
 };
+use track::{AtomicDirtyEvent, DirtyEvent};
+
+pub use arrangement::Arrangement;
+pub use meter::{Denominator, Meter, Numerator};
+pub use position::Position;
+pub use track::{AudioTrack, MidiTrack, Track};
+pub use track_clip::{resample, AudioClip, InterleavedAudio, MidiNote, TrackClip};
 
 mod arrangement;
-pub use arrangement::Arrangement;
-
 mod meter;
-pub use meter::{Denominator, Meter, Numerator};
-
 mod position;
-pub use position::Position;
-
 mod track;
-pub(in crate::generic_back) use track::{AtomicDirtyEvent, DirtyEvent};
-pub use track::{AudioTrack, MidiTrack, Track};
-
 mod track_clip;
-pub use track_clip::{resample, AudioClip, InterleavedAudio, MidiNote, TrackClip};
 
 pub fn build_output_stream(arrangement: Arc<Arrangement>) -> Stream {
     let device = cpal::default_host().default_output_device().unwrap();

--- a/src/generic_back/track.rs
+++ b/src/generic_back/track.rs
@@ -1,11 +1,11 @@
 use crate::generic_back::{Position, TrackClip};
 use std::sync::{atomic::Ordering::SeqCst, Arc, RwLock};
 
-mod audio_track;
 pub use audio_track::AudioTrack;
-
-mod midi_track;
 pub use midi_track::{AtomicDirtyEvent, DirtyEvent, MidiTrack};
+
+mod audio_track;
+mod midi_track;
 
 #[derive(Debug)]
 pub enum Track {

--- a/src/generic_back/track/midi_track.rs
+++ b/src/generic_back/track/midi_track.rs
@@ -1,14 +1,16 @@
-use crate::generic_back::{pan, Meter, Position, Track, TrackClip};
-use generic_clap_host::ClapPlugin;
+use crate::{
+    clap_host::ClapPlugin,
+    generic_back::{pan, Meter, Position, Track, TrackClip},
+};
 use plugin_state::PluginState;
 use portable_atomic::AtomicF32;
 use std::sync::{atomic::Ordering::SeqCst, Arc, Mutex, RwLock};
 
-mod dirty_event;
 pub use dirty_event::{AtomicDirtyEvent, DirtyEvent};
-
-mod plugin_state;
 pub use plugin_state::BUFFER_SIZE;
+
+mod dirty_event;
+mod plugin_state;
 
 #[derive(Debug)]
 pub struct MidiTrack {

--- a/src/generic_back/track/midi_track.rs
+++ b/src/generic_back/track/midi_track.rs
@@ -1,5 +1,5 @@
 use crate::{
-    clap_host::ClapPlugin,
+    clap_host::ClapPluginWrapper,
     generic_back::{pan, Meter, Position, Track, TrackClip},
 };
 use plugin_state::PluginState;
@@ -26,7 +26,7 @@ pub struct MidiTrack {
 }
 
 impl MidiTrack {
-    pub fn create(plugin: ClapPlugin, meter: Arc<Meter>) -> Arc<Track> {
+    pub fn create(plugin: ClapPluginWrapper, meter: Arc<Meter>) -> Arc<Track> {
         Arc::new(Track::Midi(Self {
             clips: Arc::new(RwLock::default()),
             volume: AtomicF32::new(1.0),

--- a/src/generic_back/track/midi_track/plugin_state.rs
+++ b/src/generic_back/track/midi_track/plugin_state.rs
@@ -58,7 +58,7 @@ impl PluginState {
 
         let (buffers, _) =
             self.plugin
-                .inner
+                .inner()
                 .process_audio(input_audio, input_ports, output_ports, buffer);
         (0..BUFFER_SIZE).for_each(|i| {
             let i = i * 2;
@@ -72,7 +72,7 @@ impl PluginState {
     fn get_input_events(&mut self, global_time: u32) -> EventBuffer {
         let mut buffer = EventBuffer::new();
 
-        let steady_time = self.plugin.inner.get_counter();
+        let steady_time = self.plugin.inner().get_counter();
 
         let steady_time = u32::try_from(steady_time).unwrap();
         match self.dirty.load(SeqCst) {

--- a/src/generic_back/track/midi_track/plugin_state.rs
+++ b/src/generic_back/track/midi_track/plugin_state.rs
@@ -1,13 +1,13 @@
-use crate::generic_back::{AtomicDirtyEvent, DirtyEvent, MidiNote};
-use generic_clap_host::{
-    clack_host::{
-        events::{
-            event_types::{NoteOffEvent, NoteOnEvent},
-            Match, Pckn,
-        },
-        prelude::{AudioPorts, EventBuffer},
+use crate::{
+    clap_host::ClapPlugin,
+    generic_back::{AtomicDirtyEvent, DirtyEvent, MidiNote},
+};
+use clack_host::{
+    events::{
+        event_types::{NoteOffEvent, NoteOnEvent},
+        Match, Pckn,
     },
-    ClapPlugin,
+    prelude::{AudioPorts, EventBuffer},
 };
 use std::sync::{atomic::Ordering::SeqCst, Arc, Mutex};
 

--- a/src/generic_back/track_clip.rs
+++ b/src/generic_back/track_clip.rs
@@ -1,11 +1,11 @@
 use crate::generic_back::Position;
 use std::sync::Arc;
 
-mod audio_clip;
 pub use audio_clip::{resample, AudioClip, InterleavedAudio};
-
-mod midi_clip;
 pub use midi_clip::{MidiClip, MidiNote};
+
+mod audio_clip;
+mod midi_clip;
 
 #[derive(Clone, Debug)]
 pub enum TrackClip {

--- a/src/generic_back/track_clip/audio_clip.rs
+++ b/src/generic_back/track_clip/audio_clip.rs
@@ -4,8 +4,9 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-mod interleaved_audio;
 pub use interleaved_audio::{resample, InterleavedAudio};
+
+mod interleaved_audio;
 
 #[derive(Debug)]
 pub struct AudioClip {

--- a/src/generic_back/track_clip/midi_clip.rs
+++ b/src/generic_back/track_clip/midi_clip.rs
@@ -4,11 +4,11 @@ use std::{
     sync::{atomic::Ordering::SeqCst, Arc, RwLock},
 };
 
-mod midi_note;
 pub use midi_note::MidiNote;
-
-mod midi_pattern;
 pub use midi_pattern::MidiPattern;
+
+mod midi_note;
+mod midi_pattern;
 
 #[derive(Debug)]
 pub struct MidiClip {

--- a/src/generic_front/clap_host.rs
+++ b/src/generic_front/clap_host.rs
@@ -1,0 +1,44 @@
+use crate::clap_host::{ClapPlugin, ClapPluginWrapper};
+use iced::{
+    window::{close_events, resize_events, Id},
+    Size, Subscription, Task,
+};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug)]
+pub enum Message {
+    Opened((Id, ClapPluginWrapper)),
+    Closed(Id),
+    Resized((Id, Size)),
+}
+
+#[derive(Default)]
+pub struct ClapHost {
+    windows: HashMap<Id, ClapPlugin>,
+}
+
+impl ClapHost {
+    pub fn update(&mut self, message: Message) -> Task<Message> {
+        match message {
+            Message::Opened((id, plugin)) => {
+                self.windows.insert(id, plugin.into_inner());
+            }
+            Message::Resized((id, size)) => {
+                if let Some(plugin) = self.windows.get_mut(&id) {
+                    plugin.resize(size);
+                }
+            }
+            Message::Closed(id) => {
+                self.windows.remove(&id).unwrap().destroy();
+            }
+        }
+        Task::none()
+    }
+
+    pub fn subscription() -> Subscription<Message> {
+        Subscription::batch([
+            resize_events().map(Message::Resized),
+            close_events().map(Message::Closed),
+        ])
+    }
+}

--- a/src/generic_front/clap_host.rs
+++ b/src/generic_front/clap_host.rs
@@ -29,7 +29,14 @@ impl ClapHost {
                 }
             }
             Message::Closed(id) => {
-                self.windows.remove(&id).unwrap().destroy();
+                if let Some(plugin) = self.windows.remove(&id) {
+                    plugin.destroy();
+                } else {
+                    self.windows
+                        .drain()
+                        .for_each(|(_, plugin)| plugin.destroy());
+                    return iced::exit();
+                }
             }
         }
         Task::none()

--- a/src/generic_front/mod.rs
+++ b/src/generic_front/mod.rs
@@ -104,7 +104,10 @@ impl Daw {
         match message {
             Message::Ping => {}
             Message::Test => {
-                let (id, fut) = window::open(Settings::default());
+                let (id, fut) = window::open(Settings {
+                    exit_on_close_request: false,
+                    ..Settings::default()
+                });
                 let embed = window::run_with_handle(id, move |handle| {
                     (
                         id,
@@ -120,7 +123,7 @@ impl Daw {
                     )
                 });
                 return Task::batch([
-                    fut.map(|_| Message::Ping),
+                    fut.discard(),
                     embed.map(ClapHostMessage::Opened).map(Message::ClapHost),
                 ]);
             }

--- a/src/generic_front/mod.rs
+++ b/src/generic_front/mod.rs
@@ -2,6 +2,7 @@ use crate::generic_back::{
     build_output_stream, resample, Arrangement as ArrangementInner, AudioClip, AudioTrack,
     Denominator, InterleavedAudio, Numerator,
 };
+use async_std::channel;
 use cpal::Stream;
 use home::home_dir;
 use iced::{
@@ -94,7 +95,7 @@ impl Daw {
             Message::Ping => {}
             Message::ThemeChanged(theme) => self.theme = theme,
             Message::LoadSample(path) => {
-                let (tx, rx) = async_channel::bounded(1);
+                let (tx, rx) = channel::bounded(1);
 
                 let arrangement = self.arrangement.clone();
                 std::thread::spawn(move || {

--- a/src/generic_front/mod.rs
+++ b/src/generic_front/mod.rs
@@ -24,15 +24,13 @@ use std::{
     sync::{atomic::Ordering::SeqCst, Arc},
 };
 use strum::VariantArray as _;
+use timeline_position::TimelinePosition;
+use timeline_scale::TimelineScale;
+use widget::{Arrangement, VSplit};
 
 mod timeline_position;
-pub(in crate::generic_front) use timeline_position::TimelinePosition;
-
 mod timeline_scale;
-pub(in crate::generic_front) use timeline_scale::TimelineScale;
-
 mod widget;
-use widget::{Arrangement, VSplit};
 
 static ON_BAR_CLICK: &[f32] = include_f32s!("../../assets/on_bar_click.pcm");
 static OFF_BAR_CLICK: &[f32] = include_f32s!("../../assets/off_bar_click.pcm");

--- a/src/generic_front/mod.rs
+++ b/src/generic_front/mod.rs
@@ -54,6 +54,7 @@ pub enum Message {
     ClapHost(ClapHostMessage),
     #[default]
     Ping,
+    #[expect(dead_code)]
     Test,
     ThemeChanged(Theme),
     LoadSample(PathBuf),
@@ -108,15 +109,16 @@ impl Daw {
                     exit_on_close_request: false,
                     ..Settings::default()
                 });
+                let sample_rate = self.arrangement.meter.sample_rate.load(SeqCst).into();
                 let embed = window::run_with_handle(id, move |handle| {
                     (
                         id,
                         ClapPluginWrapper::new(open_gui(
                             &get_installed_plugins()[0],
                             PluginAudioConfiguration {
-                                max_frames_count: 128,
-                                min_frames_count: 128,
-                                sample_rate: 44100.0,
+                                max_frames_count: 256,
+                                min_frames_count: 256,
+                                sample_rate,
                             },
                             handle.as_raw(),
                         )),
@@ -251,7 +253,6 @@ impl Daw {
                 .label("Metronome")
                 .on_toggle(|_| Message::ToggleMetronome),
             horizontal_space(),
-            button("TEST").on_press(Message::Test),
             pick_list(Theme::ALL, Some(&self.theme), Message::ThemeChanged),
         ]
         .spacing(20)

--- a/src/generic_front/widget/mod.rs
+++ b/src/generic_front/widget/mod.rs
@@ -1,11 +1,9 @@
-mod arrangement;
 pub use arrangement::Arrangement;
-
-mod track;
 pub use track::Track;
-
-mod track_clip;
 pub use track_clip::TrackClip;
-
-mod vsplit;
 pub use vsplit::VSplit;
+
+mod arrangement;
+mod track;
+mod track_clip;
+mod vsplit;

--- a/src/generic_front/widget/track_clip.rs
+++ b/src/generic_front/widget/track_clip.rs
@@ -19,24 +19,13 @@ use iced::{
     widget::text::{LineHeight, Shaping, Wrapping},
     Element, Font, Length, Pixels, Point, Rectangle, Renderer, Size, Theme, Vector,
 };
-use std::{
-    cmp::max_by,
-    fmt::{Debug, Formatter},
-    rc::Rc,
-    sync::Arc,
-};
+use std::{cmp::max_by, rc::Rc, sync::Arc};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TrackClip {
     inner: Arc<TrackClipInner>,
     /// information about the scale of the timeline viewport
     scale: Rc<TimelineScale>,
-}
-
-impl Debug for TrackClip {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("").field(&self.inner).finish_non_exhaustive()
-    }
 }
 
 impl<Message> Widget<Message, Theme, Renderer> for TrackClip {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> Result {
     application("GenericDAW", Daw::update, Daw::view)
         .font(REQUIRED_FONT_BYTES)
         .font(BOOTSTRAP_FONT_BYTES)
-        .subscription(Daw::subscription)
+        .subscription(|_| Daw::subscription())
         .theme(Daw::theme)
         .antialiasing(true)
         .run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
+use generic_front::Daw;
 use iced::{application, Result};
 use iced_fonts::{BOOTSTRAP_FONT_BYTES, REQUIRED_FONT_BYTES};
 
+mod clap_host;
 mod generic_back;
-
 mod generic_front;
-use generic_front::Daw;
 
 fn main() -> Result {
     #[cfg(target_os = "linux")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,14 @@ mod generic_front;
 use generic_front::Daw;
 
 fn main() -> Result {
+    #[cfg(target_os = "linux")]
+    unsafe {
+        if std::env::var("WINIT_X11_SCALE_FACTOR").is_err() {
+            std::env::set_var("WINIT_X11_SCALE_FACTOR", "1.0");
+        }
+        std::env::remove_var("WAYLAND_DISPLAY");
+    }
+
     application("GenericDAW", Daw::update, Daw::view)
         .font(REQUIRED_FONT_BYTES)
         .font(BOOTSTRAP_FONT_BYTES)


### PR DESCRIPTION
Would have liked to have fully working clap hosting, however iced currently doesn't allow embedding foreign windows. Will pick this back up once something changes in iced-land.

We can find valid clap bundles, run their plugin factory, attach them to an iced-provided window, and yeet the plugin instances when their respective window closes. However, the plugin doesn't render anything useful, and we're using the giga-unsafe-ub type in places I'd rather not (temporarily)